### PR TITLE
Swaped huron, updated LAAT/i prices

### DIFF
--- a/Missionframework/presets/blufor/custom.sqf
+++ b/Missionframework/presets/blufor/custom.sqf
@@ -22,7 +22,7 @@ FOB_box_typename = "B_Slingload_01_Cargo_F";                            // This 
 FOB_truck_typename = "BNA_KC_Gammoth_Device";                           // This is the FOB as a vehicle.
 Arsenal_typename = "B_supplyCrate_F";                                   // This is the virtual arsenal as portable supply crates.
 Respawn_truck_typename = "BNA_KC_Gammoth_Medical";                      // This is the mobile respawn (and medical) truck.
-huron_typename = "BNA_KC_Rho";                                          // This is Spartan 01, a multipurpose mobile respawn as a helicopter.
+huron_typename = "BNA_KC_Rho_crateMedical";                             // This is Spartan 01, a multipurpose mobile respawn as a helicopter.
 crewman_classname = "BNA_KC_Unit_Phase2_Tanker_CT";                     // This defines the crew for vehicles.
 pilot_classname = "BNA_KC_Unit_Phase2_CXA";                             // This defines the pilot for helicopters.
 KP_liberation_little_bird_classname = "BNA_KC_LAATi_MK2";               // These are the little birds which spawn on the Freedom or at Chimera base.
@@ -103,8 +103,8 @@ air_vehicles = [
     ["JLTS_UAV_prowler_gar",75,0,25],                                   // Recon Drone
     ["BNA_KC_Rho",300,100,175],                                         // NU Class Shuttle
     ["BNA_KC_LAATi_MK1",400,200,250],                                   // LAAT/i MK-1 (Ball turrets)
-    ["BNA_KC_LAATi_MK2",300,80,175],                                    // LAAT/i MK-2 (Doors)
-    ["BNA_KC_LAATc",500,0,400],                                         // LAAT/c
+    ["BNA_KC_LAATi_MK2",300,150,250],                                   // LAAT/i MK-2 (Doors)
+    ["BNA_KC_LAATc",500,50,400],                                        // LAAT/c
     ["BNA_KC_RepublicTransport",750,0,600],                             // Republic Transport
     ["3AS_Z95_Republic",500,400,350],                                   // Z-95 Head Hunter
     ["BNA_KC_ARC170",1500,1750,450],                                    // ARC-170


### PR DESCRIPTION
## Description
Swapped the "huron" vehicle to be the Rho medical crate, fixed prices for LAAT variants

## Changes
- Swapped "huron" vehicle to Rho crate.
- Fixed LAAT/c not costing any ammo.
- Fixed ammo/fuel costs being low for LAAT/i MK2